### PR TITLE
DscResource.Template: Update the integrate test template

### DIFF
--- a/Modules/DscResource.Common/en-US/DscResource.Common.strings.psd1
+++ b/Modules/DscResource.Common/en-US/DscResource.Common.strings.psd1
@@ -1,4 +1,4 @@
-# Localized resources for helper module CommonResourceHelper.
+# Localized resources for helper module DscResource.Common.
 
 ConvertFrom-StringData @'
     PropertyTypeInvalidForDesiredValues = Property 'DesiredValues' must be either a [System.Collections.Hashtable], [CimInstance] or [PSBoundParametersDictionary]. The type detected was {0}.

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -222,9 +222,10 @@ DscResource.Template should be mentioned here for reference by the users.
 
 ### 2019-03-17
 
-- Update the integrate test `'Should return $true when Test-DscConfiguration
-  is run'` that did not fail correctly if `Test-DscConfiguration` returned
-  'False' ([issue #14](https://github.com/PowerShell/DscResource.Template/issues/14)).
+- Update the integrate test template to version 1.3.3 because the test
+  `'Should return $true when Test-DscConfiguration is run'` that did not
+  fail correctly if `Test-DscConfiguration` returned 'False'
+  ([issue #14](https://github.com/PowerShell/DscResource.Template/issues/14)).
 - Updated some comments in files that wrongly referenced a non-existent
   module.
 

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -220,6 +220,14 @@ for more information.
 This is the change log for DscResource.Template. Any changes to the
 DscResource.Template should be mentioned here for reference by the users.
 
+### 2019-03-17
+
+- Update the integrate test `'Should return $true when Test-DscConfiguration
+  is run'` that did not fail correctly if `Test-DscConfiguration` returned
+  'False' ([issue #14](https://github.com/PowerShell/DscResource.Template/issues/14)).
+- Updated some comments in files that wrongly referenced a non-existent
+  module.
+
 ### 2019-02-03
 
 - Initial commit to repository DscResource.Template.

--- a/Tests/Integration/MSFT_Folder.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_Folder.Integration.Tests.ps1
@@ -82,7 +82,7 @@ try
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be $true
+                Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
 
@@ -133,7 +133,7 @@ try
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be $true
+                Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
     }

--- a/Tests/Integration/MSFT_Folder.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_Folder.Integration.Tests.ps1
@@ -11,10 +11,10 @@ if (Test-SkipContinuousIntegrationTask -Type 'Integration')
 
 $script:dscModuleName = 'DscResource.Template'
 $script:dscResourceFriendlyName = 'Folder'
-$script:dcsResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
 
-#region HEADER
-# Integration Test Template Version: 1.3.1
+region HEADER
+# Integration Test Template Version: 1.3.3
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
@@ -25,17 +25,21 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResource.Tests' -ChildPath 'TestHelper.psm1')) -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:dscModuleName `
-    -DSCResourceName $script:dcsResourceName `
+    -DSCResourceName $script:dscResourceName `
     -TestType Integration
 #endregion
 
 try
 {
-    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
     . $configFile
 
-    Describe "$($script:DSCResourceName)_Integration" {
-        $configurationName = "$($script:DSCResourceName)_Create_Config"
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_Create_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -70,7 +74,7 @@ try
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Present'
@@ -86,7 +90,7 @@ try
             }
         }
 
-        $configurationName = "$($script:DSCResourceName)_Remove_Config"
+        $configurationName = "$($script:dscResourceName)_Remove_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
             It 'Should compile and apply the MOF without throwing' {
@@ -121,7 +125,7 @@ try
             It 'Should have set the resource and all the parameters should match' {
                 $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
+                    -and $_.ResourceId -eq $resourceId
                 }
 
                 $resourceCurrentState.Ensure | Should -Be 'Absent'

--- a/Tests/Integration/integration_test_template.config.ps1
+++ b/Tests/Integration/integration_test_template.config.ps1
@@ -15,7 +15,7 @@
 #>
 
 #region HEADER
-# Integration Test Config Template Version: 1.2.1s
+# Integration Test Config Template Version: 1.2.1
 #endregion
 
 $configFile = [System.IO.Path]::ChangeExtension($MyInvocation.MyCommand.Path, 'json')

--- a/Tests/Integration/integration_test_template.ps1
+++ b/Tests/Integration/integration_test_template.ps1
@@ -106,7 +106,7 @@ try
             }
 
             It 'Should return $true when Test-DscConfiguration is run' {
-                Test-DscConfiguration -Verbose | Should -Be $true
+                Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
 

--- a/Tests/Integration/integration_test_template.ps1
+++ b/Tests/Integration/integration_test_template.ps1
@@ -23,7 +23,7 @@ $script:dscResourceFriendlyName = '<ResourceFriendlyName>' # TODO: Example 'Fire
 $script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)" # TODO: Update prefix
 
 #region HEADER
-# Integration Test Template Version: 1.3.2
+# Integration Test Template Version: 1.3.3
 [String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )

--- a/Tests/Unit/DscResource.LocalizationHelper.Tests.ps1
+++ b/Tests/Unit/DscResource.LocalizationHelper.Tests.ps1
@@ -1,4 +1,4 @@
-# Import the CommonResourceHelper module to test
+# Import the DscResource.LocalizationHelper module to test
 $script:resourceModulePath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
 $script:modulesFolderPath = Join-Path -Path $script:resourceModulePath -ChildPath 'Modules\DscResource.LocalizationHelper'
 

--- a/Tests/Unit/DscResource.ResourceHelper.Tests.ps1
+++ b/Tests/Unit/DscResource.ResourceHelper.Tests.ps1
@@ -1,4 +1,4 @@
-# Import the CommonResourceHelper module to test
+# Import the DscResource.Common module to test
 $script:resourceModulePath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
 $script:modulesFolderPath = Join-Path -Path $script:resourceModulePath -ChildPath 'Modules\DscResource.Common'
 


### PR DESCRIPTION
#### Pull Request (PR) description

- Update the integrate test `'Should return $true when Test-DscConfiguration
  is run'` that did not fail correctly if `Test-DscConfiguration` returned 'False' (issue #14).
- Updated some comments in files that wrongly referenced a non-existent
  module.

#### This Pull Request (PR) fixes the following issues

- Fixes #14 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the TEMPLATE\_README.md.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.template/15)
<!-- Reviewable:end -->
