### PR TITLE
Added missing comma from DscResource.Common.psm1 in Export-ModuleMember

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,7 @@
     Change to [x] for each task in the task list that applies to your PR.
     For those task that don't apply to you PR, leave those as is.
 -->
+
 - [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
       Entry should say what was changed, and how that affects users (if applicable).
 - [ ] Resource documentation added/updated in README.md.
@@ -46,5 +47,7 @@
 - [ ] Localization strings added/updated in all localization files as appropriate.
 - [ ] Examples appropriately added/updated.
 - [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
-- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
-- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
+- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing
+      Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
+- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
+      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

--- a/Modules/DscResource.Common/DscResource.Common.psm1
+++ b/Modules/DscResource.Common/DscResource.Common.psm1
@@ -488,6 +488,6 @@ Export-ModuleMember -Function @(
     'New-InvalidOperationException',
     'New-ObjectNotFoundException',
     'New-InvalidResultException',
-    'New-NotImplementedException'
+    'New-NotImplementedException',
     'Get-LocalizedData'
 )

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -220,6 +220,10 @@ for more information.
 This is the change log for DscResource.Template. Any changes to the
 DscResource.Template should be mentioned here for reference by the users.
 
+### 2019-05-12
+
+- Added missing comma from `DscResource.Common.psm1` in `Export-ModuleMember`.
+
 ### 2019-05-04
 
 - Moved all functions from `DscResource.LocalizationHelper` module into

--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -223,6 +223,7 @@ DscResource.Template should be mentioned here for reference by the users.
 ### 2019-05-12
 
 - Added missing comma from `DscResource.Common.psm1` in `Export-ModuleMember`.
+- Updated `PULL_REQUEST_TEMPLATE.md` to remove some markdown issues.
 
 ### 2019-05-04
 


### PR DESCRIPTION
#### Pull Request (PR) description

Added missing comma from `DscResource.Common.psm1` in `Export-ModuleMember`. Isn't actually a bug and doesn't fail tests, but added for consistency.

Also fixed a couple of markdown issues in the PULL_REQUEST_TEMPLATE.md.

#### This Pull Request (PR) fixes the following issues


#### Task list

- [x] Added an entry under the Unreleased section of the change log in the TEMPLATE_README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@Johlju - would you mind reviewing when you have time. Just a tiny one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/dscresource.template/26)
<!-- Reviewable:end -->
